### PR TITLE
Adds smaller integration for 2FA login - partially fixes #58

### DIFF
--- a/BingRewards/src/driver.py
+++ b/BingRewards/src/driver.py
@@ -123,7 +123,7 @@ class Driver:
 
         return options
 
-    def get_driver(path, device, headless, cookies):
+    def get_driver(path, device, headless, cookies) -> EventFiringWebDriver:
         system = platform.system()
         if system == "Windows":
             if not path.endswith(".exe"):


### PR DESCRIPTION
> :exclamation: Partially fixes #58, only for 2FA enabled using Microsoft authenticator. 

Adds the ability to print the 2FA on the output log which then the user can select on their 2FA device. 
Default wait time has been added to be 30 seconds (or until the URL redirects after successfully entering the code)

The output would be as follows:
![image](https://user-images.githubusercontent.com/738958/145113027-c4c604d3-969c-491e-8a57-3a012b888409.png)

For the longer term, this code can be sent via telegram to the phone so that users can enter the correct code when crontab is activated and the user is not active on the machine. 