### PR TITLE
Add Stats.log

### DIFF
--- a/BingRewards/src/log.py
+++ b/BingRewards/src/log.py
@@ -197,3 +197,19 @@ class Completion:
             return self.is_punchcard_completed()
         elif search_type in ('all', 'remaining'):
             return self.is_all_completed()
+
+class StatsLog:
+    __DATETIME_FORMAT = "%a, %b %d %Y %I:%M%p"
+    __LOCAL_TIMEZONE = tz.tzlocal()
+    
+    def __init__(self, points_path, run_datetime=datetime.now()):
+        self.points_path = points_path
+        self.__run_datetime = run_datetime.replace(tzinfo=self.__LOCAL_TIMEZONE)
+
+    def write(self, stats):
+        self.stats = stats
+        log_time = self.__run_datetime.strftime(self.__DATETIME_FORMAT)
+        to_log = log_time + "; " + "; ".join(self.stats) + "\n"
+
+        with open(self.points_path, "a") as log:
+                log.write(to_log)

--- a/BingRewards/src/log.py
+++ b/BingRewards/src/log.py
@@ -202,14 +202,15 @@ class StatsLog:
     __DATETIME_FORMAT = "%a, %b %d %Y %I:%M%p"
     __LOCAL_TIMEZONE = tz.tzlocal()
     
-    def __init__(self, points_path, run_datetime=datetime.now()):
-        self.points_path = points_path
+    def __init__(self, stats_path, run_datetime=datetime.now()):
+        self.stats_path = stats_path
         self.__run_datetime = run_datetime.replace(tzinfo=self.__LOCAL_TIMEZONE)
 
     def write(self, stats):
         self.stats = stats
+        
         log_time = self.__run_datetime.strftime(self.__DATETIME_FORMAT)
         to_log = log_time + "; " + "; ".join(self.stats) + "\n"
 
-        with open(self.points_path, "a") as log:
+        with open(self.stats_path, "a") as log:
                 log.write(to_log)

--- a/BingRewards/src/rewards.py
+++ b/BingRewards/src/rewards.py
@@ -1,5 +1,6 @@
 ﻿from src.driver import ChromeDriver
 from src.log import Completion
+from src.log import StatsLog
 from urllib.request import urlopen
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support.ui import WebDriverWait
@@ -16,12 +17,16 @@ from datetime import datetime, timedelta
 import json
 import ssl
 import traceback
+import os
 
 class Rewards:
     __LOGIN_URL = "https://login.live.com/"
     __BING_URL = "https://bing.com"
     __DASHBOARD_URL = "https://account.microsoft.com/rewards/"
     __TRENDS_URL = "https://trends.google.com/trends/api/dailytrends?hl=en-US&ed={}&geo=US&ns=15"
+    
+    __LOG_DIR = "logs"
+    __STATS_LOG = "stats.log"
 
     __WEB_DRIVER_WAIT_LONG = 30
     __WEB_DRIVER_WAIT_SHORT = 5
@@ -34,6 +39,7 @@ class Rewards:
         self.email = email
         self.password = password
         self.telegram_messenger = telegram_messenger
+        self.stats_log = StatsLog(os.path.join(self.__LOG_DIR, self.__STATS_LOG))
         self.debug = debug
         self.headless = headless
         self.cookies = cookies
@@ -1218,6 +1224,8 @@ class Rewards:
                     self.__sys_out(
                         f"Boo! Telegram notification NOT sent, response is: {resp}", 3
                     )
+            
+            self.stats_log.write(stats_str)
 
         except Exception as e:
             error_msg = traceback.format_exc()


### PR DESCRIPTION
Hello, I have a small PR addressing https://github.com/jjjchens235/bing-rewards/issues/136. I've been looking for a way to keep closer track of my points so I took a shot at this. I'm no professional programmer so bear with me. 

This adds a stats log that is appended when __print_stats is called. It uses the existing array of stats that are collected at the end of the run. It outputs a semi-colon separated line with timestamp. This can be changed to comma separated, or separate lines. I wasn't sure what was best here. 

Example log file output from my testing: 
```
Mon, Feb 07 2022 11:57AM; Points earned: 568; Streak count: 25; 2 days until bonus gift; Available points: 29,043; Lifetime points: 29,043
Mon, Feb 07 2022 12:01PM; Points earned: 568; Streak count: 25; 2 days until bonus gift; Available points: 29,043; Lifetime points: 29,043
```

Let me know what I can improve on!
