### PR TITLE
Start dl_try_count at 0

### DIFF
--- a/BingRewards/src/driver.py
+++ b/BingRewards/src/driver.py
@@ -163,8 +163,7 @@ class DriverFactory(ABC):
             if not os.path.exists(driver_path):
                 cls.__download_driver()
 
-        # we start at dl_try_count = 1 b/c we already downloaded the most recent version
-        dl_try_count = 1
+        dl_try_count = 0
         MAX_TRIES = 3
         is_dl_success = False
         options = cls.add_driver_options(device, headless, cookies)
@@ -178,12 +177,12 @@ class DriverFactory(ABC):
                 error_msg = str(se).lower()
                 if cls.VERSION_MISMATCH_STR not in error_msg:
                     raise SessionNotCreatedException(error_msg)
+                cls.__download_driver(dl_try_count)
                 # driver not up to date with Chrome browser, try different version
+                dl_try_count += 1
                 if dl_try_count == MAX_TRIES:
                     raise SessionNotCreatedException(
                         f'Tried downloading the {dl_try_count} most recent drivers. None match your browser version. Aborting now, please update your browser.')
-                cls.__download_driver(dl_try_count)
-                dl_try_count += 1
 
             # WebDriverException is Selenium generic exception
             except WebDriverException as wde:

--- a/BingRewards/src/driver.py
+++ b/BingRewards/src/driver.py
@@ -151,6 +151,10 @@ class DriverFactory(ABC):
 
     @classmethod
     def get_driver(cls, device, headless, cookies) -> Driver:
+        dl_try_count = 0
+        MAX_TRIES = 3
+        is_dl_success = False
+        options = cls.add_driver_options(device, headless, cookies)
 
         # raspberry pi: assumes driver already installed via `sudo apt-get install chromium-chromedriver`
         if platform.machine() in ["armv7l","aarch64"]:
@@ -162,11 +166,7 @@ class DriverFactory(ABC):
             driver_path = os.path.join(cls.DRIVERS_DIR, cls.driver_name)
             if not os.path.exists(driver_path):
                 cls.__download_driver()
-
-        dl_try_count = 0
-        MAX_TRIES = 3
-        is_dl_success = False
-        options = cls.add_driver_options(device, headless, cookies)
+                dl_try_count += 1
 
         while not is_dl_success:
             try:


### PR DESCRIPTION
Consider the case when the user already ran the program before (driver.exe exist). The user updates their browser; therefore, the driver is one version behind. The current code will download the second most recent driver and never download the most recent one, which is what the user wants. The proposed changes fix this issue.