### PR TITLE
Fix M1 Mac Chromedriver URL

### DIFF
--- a/BingRewards/src/driver.py
+++ b/BingRewards/src/driver.py
@@ -261,7 +261,7 @@ class ChromeDriverFactory(DriverFactory):
         elif system == "Darwin":
             # M1
             if platform.processor() == 'arm':
-                url = f"https://chromedriver.storage.googleapis.com/{latest_version}/chromedriver_mac64_m1.zip"
+                url = f"https://chromedriver.storage.googleapis.com/{latest_version}/chromedriver_mac_arm64.zip"
             else:
                 url = f"https://chromedriver.storage.googleapis.com/{latest_version}/chromedriver_mac64.zip"
         elif system == "Linux":


### PR DESCRIPTION
Chromedriver storage changed the name for the file for M1 macs from chromedriver_mac64_m1.zip to chromedriver_mac_arm64.zip which is causing errors.