### PR TITLE
added new dashboard url for rewards

### DIFF
--- a/BingRewards/src/rewards.py
+++ b/BingRewards/src/rewards.py
@@ -22,7 +22,7 @@ from typing import List
 class Rewards:
     __LOGIN_URL = "https://login.live.com/"
     __BING_URL = "https://bing.com"
-    __DASHBOARD_URL = "https://rewards.microsoft.com/"
+    __DASHBOARD_URL = "https://rewards.bing.com/"
 
     __WEB_DRIVER_WAIT_LONG = 30
     __WEB_DRIVER_WAIT_SHORT = 5
@@ -211,7 +211,8 @@ class Rewards:
                 # 'any_of' checks for either condition
                 EC.any_of(
                     EC.url_contains("https://rewards.microsoft.com/?redref"),
-                    EC.url_contains("https://rewards.microsoft.com/")
+                    EC.url_contains("https://rewards.microsoft.com/"),                    
+                    EC.url_contains("https://rewards.bing.com/"),                    
                 )
             )
             # need to sign in via welcome page first


### PR DESCRIPTION
Updated the dashboard url. The old url was causing timeout issue as the url was not found anymore.

![image](https://user-images.githubusercontent.com/13816261/204801746-590e0d78-5f8d-48a3-9b0b-7ab75c304b32.png)

![image](https://user-images.githubusercontent.com/13816261/204801903-d5a827cb-aedf-436e-afe5-65235c13781f.png)

